### PR TITLE
fix: correct typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Welcome! This repository is designed to help you make your very first pull reque
 - How to fork a repository
 - How to clone your fork locally
 - How to create a branch
-- How to make changes and cot them
+- How to make changes and commit them
 - How to push changes to GitHub
-- How to create a pull reques
+- How to create a pull request
 
 ## Your Mission 🎯
 
@@ -70,7 +70,7 @@ git push origin fix-typos
 ### 7. Create a Pull Request
 
 1. Go to your fork on GitHub
-1. Click "Compare & pill request"
+1. Click "Compare & pull request"
 1. Add a clear title like "Fix typos in README.md"
 1. Describe what you fixed
 1. Click "Create pull request"


### PR DESCRIPTION
Fixes three typos in README.md as described in #19: 'cot' → 'commit', 'reques' → 'request', and 'pill' → 'pull'. These were the intentional errors planted for contributors to find and fix.

---

_This contribution was AI-assisted (Claude). It's a small targeted fix — happy to revise, or just close if it's not a direction you want. No offense taken._